### PR TITLE
Split leading & trailing text into new text nodes

### DIFF
--- a/atd.core.js
+++ b/atd.core.js
@@ -1,6 +1,6 @@
 /*
  * atd.core.js - A building block to create a front-end for AtD
- * Author      : Raphael Mudge
+ * Author      : Raphael Mudge, Automattic
  * License     : LGPL
  * Project     : http://open.afterthedeadline.com
  * Discuss     : https://groups.google.com/forum/#!forum/atd-developers
@@ -343,6 +343,46 @@ AtDCore.prototype.markMyWords = function(container_nodes, errors) {
 	var ecount = 0; /* track number of highlighted errors */
 	var parent = this;
 
+	/**
+	 * Split a text node into an ordered list of siblings:
+	 * - text node to the left of the match
+	 * - the element replacing the match
+	 * - text node to the right of the match
+	 *
+	 * We have to leave the text to the left and right of the match alone
+	 * in order to prevent XSS
+	 * 
+	 * @return array
+	 */
+	function splitTextNode( textnode, regexp, replacement ) {
+		var text = textnode.nodeValue,
+			index = text.search( regexp ),
+			match = text.match( regexp ),
+			captured = [],
+			cursor;
+
+		if ( index < 0 || ! match.length ) {
+			return [ textnode ];
+		}
+
+		if ( index > 0 ) {
+			// capture left text node
+			captured.push( document.createTextNode( text.substr( 0, index ) ) );
+		}
+
+		// capture the replacement of the matched string
+		captured.push( parent.create( match[0].replace( regexp, replacement ) ) );
+
+		cursor = index + match[0].length;
+
+		if ( cursor < text.length ) {
+			// capture right text node
+			captured.push( document.createTextNode( text.substr( cursor ) ) );
+		}
+
+		return captured;
+	}
+
 	/* Collect all text nodes */
 	/* Our goal--ignore nodes that are already wrapped */
    
@@ -422,6 +462,8 @@ AtDCore.prototype.markMyWords = function(container_nodes, errors) {
 					   because eventually the whole thing gets wrapped in an mceItemHidden span and from there it's necessary to
 					   handle each node individually. */
 					var bringTheHurt = function(node) {
+						var span, splitNodes;
+
 						if (node.nodeType == 3) {
 							ecount++;
 
@@ -429,8 +471,17 @@ AtDCore.prototype.markMyWords = function(container_nodes, errors) {
 							   a non-breaking space.  The markup removal code substitutes this span for a space later */
 							if (parent.isIE() && node.nodeValue.length > 0 && node.nodeValue.substr(0, 1) == ' ')
 								return parent.create('<span class="mceItemHidden">&nbsp;</span>' + node.nodeValue.substr(1, node.nodeValue.length - 1).replace(regexp, result), false);
-							else
-								return parent.create(node.nodeValue.replace(regexp, result), false);
+							else {
+								splitNodes = splitTextNode( node, regexp, result );
+								span = parent.create( '<span />' );
+
+								for ( var i = 0; i < splitNodes.length; i++ ) {
+									span.appendChild( splitNodes[i] );
+								}
+
+								node = span;
+								return node;
+							}
 						} 
 						else {
 							var contents = parent.contents(node);


### PR DESCRIPTION
Previous behavior was to create a new HTML element with the whole thing thereby executing scripts (XSS) in the surrounding text (in some browsers).

@martinremy -- you're the only other participant here, so assigning to you for a look before merging :)
